### PR TITLE
Fix public model name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ git clone https://huggingface.co/THUDM/glm-4-voice-decoder
 ### Launch Web Demo
 首先启动模型服务
 ```shell
-python model_server.py --model-path glm-4-voice-9b
+python model_server.py --model-path 'THUDM/glm-4-voice-9b'
 ```
 此命令会自动下载 `glm-4-voice-9b`。如果网络条件不好，也手动下载之后通过 `--model-path` 指定本地的路径。
 

--- a/README_en.md
+++ b/README_en.md
@@ -43,7 +43,7 @@ git clone https://huggingface.co/THUDM/glm-4-voice-decoder
 ### Launch Web Demo
 First, start the model service
 ```shell
-python model_server.py --model-path glm-4-voice-9b
+python model_server.py --model-path 'THUDM/glm-4-voice-9b'
 ```
 
 Then, start the web service


### PR DESCRIPTION
Calling `python model_server.py --model-path glm-4-voice-9b` fails since the model is not publicly found at `https://huggingface.co/glm-4-voice-9b`, but using `https://huggingface.co/THUDM/glm-4-voice-9b` works fine.

(使用谷歌翻译翻译)
调用“python model_server.py --model-path glm-4-voice-9b”失败，因为该模型未在“https://huggingface.co/glm-4-voice-9b”公开找到，但使用“https://huggingface.co/THUDM/glm-4-voice-9b”可以正常工作。